### PR TITLE
Fix tap issues

### DIFF
--- a/tap_sailthru/schemas/blast_query.json
+++ b/tap_sailthru/schemas/blast_query.json
@@ -26,19 +26,22 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "open_time": {
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "click_time": {
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "first_ten_clicks": {
       "type": [
@@ -50,7 +53,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "device": {
       "type": [
@@ -62,7 +66,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     }
   }
 }

--- a/tap_sailthru/schemas/blast_repeats.json
+++ b/tap_sailthru/schemas/blast_repeats.json
@@ -76,8 +76,7 @@
       "type": [
         "null",
         "integer"
-      ],
-      "format": "date-time"
+      ]
     },
     "suppress_list": {
       "type": [
@@ -101,8 +100,7 @@
       "type": [
         "null",
         "string"
-      ],
-      "format": "date-time"
+      ]
     },
     "start_date": {
       "type": [

--- a/tap_sailthru/schemas/blast_repeats.json
+++ b/tap_sailthru/schemas/blast_repeats.json
@@ -30,25 +30,29 @@
     },
     "previous_blast_id": {
       "type": [
-        "null"
+        "null",
+        "integer"
       ]
     },
     "message_criteria": {
       "type": [
-        "null"
+        "null",
+        "string"
       ]
     },
     "create_time": {
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "modify_time": {
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "create_user": {
       "type": [
@@ -72,11 +76,13 @@
       "type": [
         "null",
         "integer"
-      ]
+      ],
+      "format": "date-time"
     },
     "suppress_list": {
       "type": [
-        "null"
+        "null",
+        "string"
       ]
     },
     "template": {
@@ -95,19 +101,22 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "start_date": {
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "end_date": {
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "report_email": {
       "type": [
@@ -125,7 +134,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "errors": {
       "type": [

--- a/tap_sailthru/schemas/blast_save_list.json
+++ b/tap_sailthru/schemas/blast_save_list.json
@@ -38,7 +38,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "signup": {
       "type": [
@@ -86,7 +87,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "list_signup": {
       "type": [
@@ -128,7 +130,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "purchase_count": {
       "type": [
@@ -152,7 +155,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "largest_purchase item_price": {
       "type": [

--- a/tap_sailthru/schemas/blasts.json
+++ b/tap_sailthru/schemas/blasts.json
@@ -102,19 +102,22 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "modify_time": {
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "schedule_time": {
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "email_count": {
       "type": [

--- a/tap_sailthru/schemas/lists.json
+++ b/tap_sailthru/schemas/lists.json
@@ -32,7 +32,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "type": {
       "type": [

--- a/tap_sailthru/schemas/purchase_log.json
+++ b/tap_sailthru/schemas/purchase_log.json
@@ -8,7 +8,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "email_hash": {
       "type": [

--- a/tap_sailthru/schemas/users.json
+++ b/tap_sailthru/schemas/users.json
@@ -24,7 +24,8 @@
     },
     "vars": {
       "type": [
-        "null"
+        "null",
+        "string"
       ]
     },
     "lists": {

--- a/tap_sailthru/streams.py
+++ b/tap_sailthru/streams.py
@@ -282,7 +282,7 @@ class BlastQuery(FullTableStream):
     Docs: https://getstarted.sailthru.com/developers/api/job/#blast-query
     """
     tap_stream_id = 'blast_query'
-    key_properties = ['profile_id']
+    key_properties = ['profile_id', 'blast_id']
     params = {
         'job': 'blast_query',
         'blast_id': '{blast_id}',


### PR DESCRIPTION
# Description of change
Uncovered some small issues during functional testing. Made the following fixes:
- Adding second key property to blast query stream as a profile can belong to multiple blasts (campaigns).
- Adding `date-time` formatting to datetime fields.
- Was previously only converting dates to datetimes to make comparisons but was not emitting dates in RFC 3339 format. Added helper method to make this conversion for all date fields per stream.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
