### PR TITLE
Check 'lists' key against None in user response

### DIFF
--- a/tap_sailthru/transform.py
+++ b/tap_sailthru/transform.py
@@ -45,7 +45,7 @@ def flatten_user_response(response: dict) -> dict:
         'cookie': response.get('keys', {}).get('cookie'),
         'email': response.get('keys', {}).get('email'),
         'vars': response.get('vars'),
-        'lists': list(response.get('lists', {}).keys()),
+        'lists': list((response.get('lists') or {}).keys()),  # 'lists' key may exist but may be None
         'engagement': response.get('engagement'),
         'optout_email': response.get('optout_email'),
     }

--- a/tests/unittests/test_transform.py
+++ b/tests/unittests/test_transform.py
@@ -74,6 +74,18 @@ def test_flatten_user_response():
             'optout_email': None,
             }
         },
+        {'case': {
+            'lists': None},
+        'expected': {
+            'profile_id': None,
+            'cookie': None,
+            'email': None,
+            'vars': None,
+            'lists': [],
+            'engagement': None,
+            'optout_email': None,
+            }
+        },
     ]
 
     for test_case in test_cases:


### PR DESCRIPTION
# Description of change

This PR fixes the case when Sailthru user response contains `None` for a `'lists'` key.

I'm using this tap via Stitch Sailthru Connector on quite big dataset. After some time I started getting the following error.

It seems that for a big enough dataset there may be a case where `lists` key for user API response is `null` which in fact was not taken into account in the current codebase.

```
2022-06-15 11:58:11,808Z    tap - CRITICAL 'NoneType' object has no attribute 'keys'
2022-06-15 11:58:11,808Z    tap - Traceback (most recent call last):
2022-06-15 11:58:11,808Z    tap -   File "/code/orchestrator/tap-env/bin/tap-sailthru", line 33, in <module>
2022-06-15 11:58:11,808Z    tap -     sys.exit(load_entry_point('tap-sailthru==0.2.0', 'console_scripts', 'tap-sailthru')())
2022-06-15 11:58:11,808Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/singer/utils.py", line 229, in wrapped
2022-06-15 11:58:11,808Z    tap -     return fnc(*args, **kwargs)
2022-06-15 11:58:11,809Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_sailthru/__init__.py", line 33, in main
2022-06-15 11:58:11,809Z    tap -     sync(args.config, args.state, catalog)
2022-06-15 11:58:11,809Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_sailthru/sync.py", line 38, in sync
2022-06-15 11:58:11,809Z    tap -     state = stream_obj.sync(state, stream_schema, stream_metadata, config, transformer)
2022-06-15 11:58:11,809Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_sailthru/streams.py", line 228, in sync
2022-06-15 11:58:11,809Z    tap -     for record in self.get_records():
2022-06-15 11:58:11,809Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_sailthru/streams.py", line 433, in get_records
2022-06-15 11:58:11,809Z    tap -     yield flatten_user_response(response)
2022-06-15 11:58:11,809Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_sailthru/transform.py", line 48, in flatten_user_response
2022-06-15 11:58:11,809Z    tap -     'lists': list(response.get('lists', {}).keys()),
2022-06-15 11:58:11,809Z    tap - AttributeError: 'NoneType' object has no attribute 'keys'
```

# Manual QA steps

I'm running this tap via Stitch against pretty big dataset so I can do the QA once it's merged and released to Stitch.
 
# Risks

I suspect that other values in Sailthru responses may be `null` (`None`) as well but let's worry about that once there is an evidence for that.
 
# Rollback steps
 - revert this branch
