### PR TITLE
TDL-21954 & TDL-21991 Bugfixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-sailthru/bin/activate
             pip install 'pip==21.1.3'
             pip install 'setuptools==56.0.0'
-            pip install .[test]
+            pip install .[dev]
             pip install pytest-cov
       - persist_to_workspace:
           root: /usr/local/share/virtualenvs/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,41 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
-jobs:
-  build:
+
+executors:
+  tap_tester:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+jobs:
+  ensure_env:
+    executor: tap_tester
     steps:
       - checkout
       - run:
           name: 'Setup virtual env'
           command: |
-            python3 -mvenv /usr/local/share/virtualenvs/tap-sailthru
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /usr/local/share/virtualenvs/dev_env.sh
+            python3 -m venv /usr/local/share/virtualenvs/tap-sailthru/
             source /usr/local/share/virtualenvs/tap-sailthru/bin/activate
             pip install 'pip==21.1.3'
             pip install 'setuptools==56.0.0'
             pip install .[test]
             pip install pytest-cov
-      - run:
-          name: 'JSON Validator'
-          command: |
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json tap_sailthru/schemas/*.json
+      - persist_to_workspace:
+          root: /usr/local/share/virtualenvs/
+          paths:
+            - tap-sailthru
+            - dev_env.sh
+  build:
+    executor: tap_tester
+    steps:
+      - run: echo "Tests have passed."
+  run_pylint_and_unittests:
+    executor: tap_tester
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /usr/local/share/virtualenvs
       - run:
           name: 'pylint'
           command: |
@@ -31,38 +46,100 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-sailthru/bin/activate
             python -m pytest --junitxml=junit/test-result.xml --cov=tap_sailthru --cov-report=html tests/unittests/
-      - add_ssh_keys
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:
           path: htmlcov
       - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json tap_sailthru/schemas/*.json
+  integration_test:
+    parameters:
+      test_command:
+        type: string
+    executor: tap_tester
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /usr/local/share/virtualenvs
+      - run:
           name: 'Integration Tests'
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
-            source dev_env.sh
+            source /usr/local/share/virtualenvs/dev_env.sh
+            mkdir /tmp/${CIRCLE_PROJECT_REPONAME}
+            export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-sailthru tests
+            << parameters.test_command >>
       - slack/notify-on-failure:
           only_for_branches: master
+      - store_artifacts:
+          path: /tmp/tap-sailthru
+
 workflows:
   version: 2
-  commit:
+  commit: &commit_jobs
     jobs:
+      - ensure_env:
+          context:
+            - circleci-user
+      - run_pylint_and_unittests:
+          context:
+            - circleci-user
+          requires:
+            - ensure_env
+      - integration_test:
+          name: "Discovery Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
+          requires:
+            - ensure_env
+      - integration_test:
+          name: "Automatic Fields Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_automatic_fields.py
+          requires:
+            - ensure_env
+      - integration_test:
+          name: "Start Date Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
+          requires:
+            - ensure_env
+      - integration_test:
+          name: "All Fields Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_fields.py
+          requires:
+            - ensure_env
+      - integration_test:
+          name: "Bookmarks Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_bookmark.py
+          requires:
+            - ensure_env
       - build:
           context:
             - circleci-user
-            - tap-tester-user
+          requires:
+            - "Bookmarks Test"
   build_daily:
+    <<: *commit_jobs
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 1 * * *"
           filters:
             branches:
               only:
                 - master
-    jobs:
-      - build:
-          context:
-            - circleci-user
-            - tap-tester-user

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(join(ROOT_DIR, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="tap-sailthru",
-    version="0.2.0",
+    version="1.0.0",
     description="Singer.io tap for the SailThru API",
     long_description=readme,
     long_description_content_type='text/markdown',
@@ -19,48 +19,14 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_sailthru"],
     install_requires=[
-        'appnope==0.1.2',
-	'astroid==2.5.2',
-	'attrs==20.3.0',
-	'backcall==0.2.0',
-	'backoff==1.8.0',
-	'certifi==2020.12.5',
-	'chardet==4.0.0',
-	'ciso8601==2.1.3',
-	'decorator==4.4.2',
-	'idna==2.10',
-	'iniconfig==1.1.1',
-	'ipython==7.21.0',
-	'ipython-genutils==0.2.0',
-	'isort==5.8.0',
-	'jedi==0.18.0',
-	'jsonschema==2.6.0',
-	'lazy-object-proxy==1.6.0',
-	'mccabe==0.6.1',
-	'packaging==20.9',
-	'parso==0.8.1',
-	'pexpect==4.8.0',
-	'pickleshare==0.7.5',
-	'pluggy==0.13.1',
-	'prompt-toolkit==3.0.17',
-	'ptyprocess==0.7.0',
-	'py==1.10.0',
-	'Pygments==2.8.1',
-	'pylint==2.7.4',
-	'pyparsing==2.4.7',
-	'pytest==6.2.3',
-	'python-dateutil==2.8.1',
-	'pytz==2018.4',
 	'requests==2.25.1',
-	'simplejson==3.11.1',
 	'singer-python==5.10.0',
-	'six==1.15.0',
-	'toml==0.10.2',
-	'traitlets==5.0.5',
-	'urllib3==1.26.3',
-	'wcwidth==0.2.5',
-	'wrapt==1.12.1'
     ],
+    extras_require= {
+          'dev': [
+              'pylint==2.7.4',
+          ]
+      },
     entry_points="""
     [console_scripts]
     tap-sailthru=tap_sailthru:main

--- a/tap_sailthru/schemas/blast_query.json
+++ b/tap_sailthru/schemas/blast_query.json
@@ -46,8 +46,14 @@
     "first_ten_clicks": {
       "type": [
         "null",
-        "string"
-      ]
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
     },
     "purchase_time": {
       "type": [

--- a/tap_sailthru/schemas/blast_query.json
+++ b/tap_sailthru/schemas/blast_query.json
@@ -65,9 +65,15 @@
     "first_ten_clicks_time": {
       "type": [
         "null",
-        "string"
+        "array"
       ],
-      "format": "date-time"
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      }
     }
   }
 }

--- a/tap_sailthru/streams.py
+++ b/tap_sailthru/streams.py
@@ -5,13 +5,13 @@ This module defines the stream classes and their individual sync logic.
 import csv
 import datetime
 import time
-from datetime import date, timedelta
-from functools import lru_cache
 from typing import Any, Iterator
-
+from functools import lru_cache
+from datetime import timedelta
 import requests
 import singer
 from singer import Transformer, metrics
+from singer.utils import strftime,now as dt_now
 
 from tap_sailthru.client import SailthruClient, SailthruClientError
 from tap_sailthru.transform import (flatten_user_response,
@@ -183,9 +183,7 @@ class IncrementalStream(BaseStream):
                 transform_keys_to_snake_case(record)
                 record_datetime = singer.utils.strptime_to_utc(record[self.replication_key])
                 if record_datetime >= bookmark_datetime:
-                    transformed_record = transformer.transform(record,
-                                                               stream_schema,
-                                                               stream_metadata)
+                    transformed_record = transformer.transform(record, stream_schema, stream_metadata)
                     singer.write_record(self.tap_stream_id, transformed_record)
                     counter.increment()
                     max_datetime = max(record_datetime, max_datetime)
@@ -275,7 +273,8 @@ class Blasts(IncrementalStream):
         # by child stream
         if is_parent:
             for status in self.params['statuses']:
-                response = self.client.get_blasts({'status': status})
+                #added query for start_date to prevent fetching blast_ids older than 540 days
+                response = self.client.get_blasts({'status': status,"start_date":strftime(bookmark_datetime)})
                 yield from (blast.get('blast_id') for blast in response.get('blasts'))
         else:
             for status in self.params['statuses']:
@@ -305,10 +304,15 @@ class BlastQuery(FullTableStream):
                  'first_ten_clicks_time']
 
     def get_records(self, bookmark_datetime=None, is_parent=False):
-
-        for blast_id in self.get_parent_data():
+        
+        # sailthru api limits querying of records older than 540 days 
+        # hence filtering records from the parent stream 
+        # that exceed this limit
+        # https://getstarted.sailthru.com/analytics/message-summary/reports/#:~:text=Note%3A%20Campaign%20data%20for%20any%20of%20the%20above%20reports%20cannot%20be%20exported%20after%20540%20days.
+        date_limit = dt_now() - datetime.timedelta(days=540)
+        LOGGER.info("Fetching for blasts Since %s",date_limit)
+        for blast_id in self.get_parent_data(date_limit):
             self.params['blast_id'] = blast_id
-
             response = self.post_job(parameter=blast_id)
             if response.get("error"):
                 # https://getstarted.sailthru.com/developers/api/job/#Error_Codes

--- a/tap_sailthru/streams.py
+++ b/tap_sailthru/streams.py
@@ -12,8 +12,7 @@ import requests
 import singer
 from singer import Transformer, metrics
 from singer.utils import strftime,now as dt_now
-from singer.transform import SchemaMismatch
-from tap_sailthru.client import SailthruClient, SailthruClientError
+from tap_sailthru.client import SailthruClient
 from tap_sailthru.transform import (flatten_user_response,
                                     get_start_and_end_date_params,
                                     rfc2822_to_datetime,

--- a/tap_sailthru/streams.py
+++ b/tap_sailthru/streams.py
@@ -345,6 +345,7 @@ class BlastQuery(FullTableStream):
         with metrics.record_counter(self.tap_stream_id) as counter:
             for record in self.get_records():
                 transform_keys_to_snake_case(record)
+                record["first_ten_clicks"] = record["first_ten_clicks"].split()
                 record["first_ten_clicks_time"] = record["first_ten_clicks_time"].split("|")
                 transformed_record = transformer.transform(record, stream_schema, stream_metadata)
                 singer.write_record(self.tap_stream_id, transformed_record)

--- a/tap_sailthru/transform.py
+++ b/tap_sailthru/transform.py
@@ -38,14 +38,15 @@ def flatten_user_response(response: dict) -> dict:
     :param response: the dictionary representing the response object from the api call
     :return: a flattened dicitonary
     """
-
+    # fixes AttributeError that occurs when trying to access "lists/keys"
+    keys = response.get('keys') or {}
     return {
         # TODO: should we keep date value from lists key? ask brian
-        'profile_id': response.get('keys', {}).get('sid'),
-        'cookie': response.get('keys', {}).get('cookie'),
-        'email': response.get('keys', {}).get('email'),
+        'profile_id': keys.get('sid'),
+        'cookie': keys.get('cookie'),
+        'email': keys.get('email'),
         'vars': response.get('vars'),
-        'lists': list(response.get('lists', {}).keys()),
+        'lists':list((response.get('lists') or {}).keys()),
         'engagement': response.get('engagement'),
         'optout_email': response.get('optout_email'),
     }

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -18,7 +18,8 @@ class SailthruAllfieldsTest(SailthruBaseTest):
         
         
         # Streams to verify all fields tests
-        expected_streams = self.expected_sync_streams()
+        expected_streams = self.expected_sync_streams() - {"blast_query"}
+        # data not available for blast_query stream
 
         expected_automatic_fields = self.expected_automatic_fields()
         conn_id = connections.ensure_connection(self)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -18,8 +18,8 @@ class SailthruAutomaticFieldsTest(SailthruBaseTest):
         Verify that all replicated records have unique primary key values.
         """
         
-        streams_to_test = self.expected_sync_streams()
-        
+        streams_to_test = self.expected_sync_streams() - {"blast_query"}
+        # data not available for blast_query stream
         conn_id = connections.ensure_connection(self)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -27,7 +27,8 @@ class SailthruBookmarkTest(SailthruBaseTest):
             different values for the replication key
         """
 
-        expected_streams = self.expected_sync_streams()
+        expected_streams = self.expected_sync_streams() - {"blast_query"}
+        # data not available for blast_query stream
         expected_replication_keys = self.expected_replication_keys()
         expected_replication_methods = self.expected_replication_method()
 

--- a/tests/unittests/test_transform.py
+++ b/tests/unittests/test_transform.py
@@ -74,6 +74,26 @@ def test_flatten_user_response():
             'optout_email': None,
             }
         },
+        {'case': {
+            'keys': {
+                'sid': None,
+                'cookie': None,
+                'email': None,
+            },
+            'vars': None,
+            'lists': None,
+            'engagement': None,
+            'optout_email': None},
+        'expected': {
+            'profile_id': None,
+            'cookie': None,
+            'email': None,
+            'vars': None,
+            'lists': [],
+            'engagement': None,
+            'optout_email': None,
+            }
+        },
     ]
 
     for test_case in test_cases:


### PR DESCRIPTION
# Description of change
- Addresses Following Tickets [TDL-21954](https://jira.talendforge.org/browse/TDL-21954) &  [TDL-21991](https://jira.talendforge.org/browse/TDL-21991)
- **field datatype change for `blast_query` stream**
The data received for the key `first_ten_clicks_time` is in the following format:
```2023-02-14 09:10:13|2023-02-14 09:10:14|2023-02-14 09:10:20|2023-02-14 09:10:26|2023-02-14 09:10:27|2023-02-14 09:10:34|2023-02-14 09:10:35|2023-02-14 09:10:37|2023-02-14 09:10:38```
this does not satisfy the existing  schema for this key, thus updating the schema to identify `first_ten_clicks_time` as an array for date-time string
- Fixed attributerror bug in transform function while transforming user record [TDL-21954](https://jira.talendforge.org/browse/TDL-21954)
- Fixed blast_query` APi imit issue for records older than 540 days & Added Unit Test Scenario
- Fixed issue with tap exiting on no data found in stream
- https://github.com/singer-io/tap-sailthru/pull/15 Added CircleCi config for parallel exec of tests.
- https://github.com/singer-io/tap-sailthru/pull/16 Removed Extra Dependencies

# Manual QA steps
 - Cloned Connection and verified fix for [TDL-21954](https://jira.talendforge.org/browse/TDL-21954)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
